### PR TITLE
Add retention policy to backup script

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -18,9 +18,10 @@ class pe_databases::backup (
       },
     }
   ],
-  String $backup_directory         = '/opt/puppetlabs/server/data/postgresql/9.4/backups',
-  String $backup_script_path       = '/opt/puppetlabs/pe_databases/scripts/puppet_enterprise_database_backup.sh',
-  String $backup_logging_directory = '/var/log/puppetlabs/pe_databases_backup',
+  String  $backup_directory         = '/opt/puppetlabs/server/data/postgresql/9.4/backups',
+  String  $backup_script_path       = '/opt/puppetlabs/pe_databases/scripts/puppet_enterprise_database_backup.sh',
+  String  $backup_logging_directory = '/var/log/puppetlabs/pe_databases_backup',
+  Integer $retention_policy         = 2,
 ) {
 
   file { ['/opt/puppetlabs/pe_databases', '/opt/puppetlabs/pe_databases/scripts', $backup_directory ] :
@@ -49,7 +50,7 @@ class pe_databases::backup (
 
     cron { "puppet_enterprise_database_backup_${databases_to_backup}":
       ensure  => present,
-      command => "${backup_script_path} -l ${backup_logging_directory} -t ${backup_directory} ${db_string}",
+      command => "${backup_script_path} -l ${backup_logging_directory} -t ${backup_directory} -r ${retention_policy} ${db_string}",
       user    => 'pe-postgres',
       minute  => $dbs_and_schedule['schedule']['minute'],
       hour    => $dbs_and_schedule['schedule']['hour'],


### PR DESCRIPTION
To address: https://github.com/npwalker/pe_databases/issues/3

Prior to this commit, the backup script simply backed up but never
worried about preventing the storage of too many backups.

After this commit, the backup script has a retention policy and
deletes more than the desired number of backups minus 1 backups
so that the new backup can be completed.

This will likely cause valid backups to be deleted if the backups
fail and create an empty file.  Then there will be no valid backups
if nothing is done to intervene but we're choosing that option
over running out of disk space by not aggresively deleting backups.