### PR TITLE
Do not manage fact_values table in PuppetDB in PE 2017.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Z Release 0.10.1
+
+ - Bug Fixes
+   - Do not manage fact_values auto vacuum on PE 2017.2.0

--- a/manifests/postgresql_settings.pp
+++ b/manifests/postgresql_settings.pp
@@ -106,7 +106,8 @@ class pe_databases::postgresql_settings (
     }
   }
 
-  if $manage_fact_values_autovacuum_cost_delay {
+  if ( versioncmp('2017.2.0', $facts['pe_server_version']) >= 0
+       and $manage_fact_values_autovacuum_cost_delay ) {
     pe_databases::set_puppetdb_table_autovacuum_cost_delay_zero { 'fact_values' : }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_databases",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": "npwalker",
   "summary": "A Puppet Module for Backing Up / Maintaining / Tuning Your Puppet Enterprise Databases",
   "license": "Apache-2.0",


### PR DESCRIPTION
PuppetDB refactored the way facts are stored in PE 2017.2 and as
a result the fact_values table no longer exists and does not
need more aggressive autovacuuming.

Since the fact values are now inlined in the facts table, the
facts table might warrant some monitoring.

Resolves https://github.com/npwalker/pe_databases/issues/5