### PR TITLE
Fix puppet-lint issues to raise module's score

### DIFF
--- a/manifests/postgresql_settings.pp
+++ b/manifests/postgresql_settings.pp
@@ -1,4 +1,5 @@
 class pe_databases::postgresql_settings (
+  #lint:ignore:2sp_soft_tabs
   Float[0,1] $autovacuum_vacuum_scale_factor           = 0.08,
   Float[0,1] $autovacuum_analyze_scale_factor          = 0.04,
   Integer    $autovacuum_max_workers                   = max( 3, min( 8, $facts['processors']['count'] / 3)),
@@ -24,6 +25,7 @@ class pe_databases::postgresql_settings (
                                                            true  => "${facts['memory']['system']['total_bytes'] / 1024 / 1024 / 8/ $autovacuum_max_workers}MB",
                                                          },
   String     $psql_version                             = $pe_databases::psql_version,
+  #lint:endignore
 ) {
 
   $postgresql_service_resource_name = 'postgresqld'


### PR DESCRIPTION
Noticed that the module had a low score on the Forge because of these style issues. This PR should help.

There's still one more issue affecting the score, and that's the unbounded dependency on puppetlabs/postgresql. I don't know enough about compatibility to put a limit on the version, so I let that one go.