### PR TITLE
Make cronjobs to vacuum full PuppetDB tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Minor Release 0.12.0
+
+ - Improve maintenance cron jobs [#12](https://github.com/npwalker/pe_databases/pull/12)
+   - Change from reindexing all tables to VACUUM FULL on just the smaller tables
+
 ## Z Release 0.11.2
 
  - Fix metadata.json version

--- a/files/vacuum_full_tables.sh
+++ b/files/vacuum_full_tables.sh
@@ -1,0 +1,35 @@
+if [ "$1" = "" ]; then
+  echo "Usage: $0 <(facts, catalogs, or other) tables to VACUUM FULL> "
+  exit
+fi
+
+if [ "$2" = "" ]; then
+  SLEEP=300
+else
+  SLEEP=$2
+fi
+
+if [ $1 = 'facts' ]; then
+  WHERE="'facts' ,'factsets', 'fact_paths', 'fact_values'"
+elif [ $1 = 'catalogs' ]; then
+  WHERE="'catalogs' ,'catalog_resources', 'edges', 'certnames'"
+elif [ $1 = 'other' ]; then
+  WHERE="'producers' ,'resource_params', 'resource_params_cache'"
+else
+  echo "Must pass facts, catalogs, or other as first argument"
+  exit 1
+fi
+
+SQL="SELECT t.relname::varchar AS table_name
+  FROM pg_class t
+  JOIN pg_namespace n
+    ON n.oid = t.relnamespace
+  WHERE t.relkind = 'r'
+    AND t.relname IN ( $WHERE )"
+
+for TABLE in $(su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/bin/psql -d pe-puppetdb -c \"$SQL\" --tuples-only")
+do
+  #echo $TABLE
+  su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/bin/vacuumdb -d pe-puppetdb -t $TABLE --full --verbose"
+  sleep $SLEEP
+done

--- a/files/vacuum_full_tables.sh
+++ b/files/vacuum_full_tables.sh
@@ -30,6 +30,6 @@ SQL="SELECT t.relname::varchar AS table_name
 for TABLE in $(su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/bin/psql -d pe-puppetdb -c \"$SQL\" --tuples-only")
 do
   #echo $TABLE
-  su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/bin/vacuumdb -d pe-puppetdb -t $TABLE --full --verbose"
+  su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/bin/vacuumdb -d pe-puppetdb -t $TABLE --full"
   sleep $SLEEP
 done

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -20,14 +20,10 @@ class pe_databases::backup (
   ],
   String  $psql_version             = $pe_databases::psql_version,
   String  $backup_directory         = "/opt/puppetlabs/server/data/postgresql/${psql_version}/backups",
-  String  $backup_script_path       = '/opt/puppetlabs/pe_databases/scripts/puppet_enterprise_database_backup.sh',
+  String  $backup_script_path       = "${pe_databases::scripts_dir}/puppet_enterprise_database_backup.sh",
   String  $backup_logging_directory = '/var/log/puppetlabs/pe_databases_backup',
   Integer $retention_policy         = 2,
 ) {
-
-  file { ['/opt/puppetlabs/pe_databases', '/opt/puppetlabs/pe_databases/scripts', $backup_directory ] :
-    ensure => directory,
-  }
 
   file { $backup_logging_directory :
     ensure => 'directory',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,12 +2,18 @@ class pe_databases (
   Boolean $manage_database_backups     = true,
   Boolean $manage_database_maintenance = true,
   Boolean $manage_postgresql_settings  = true,
+  String  $install_dir                 = '/opt/puppetlabs/pe_databases',
+  String  $scripts_dir                 = "${install_dir}/scripts"
 ) {
 
   if ( versioncmp('2017.3.0', $facts['pe_server_version']) <= 0 ) {
     $psql_version = '9.6'
   } else {
     $psql_version = '9.4'
+  }
+
+  file { [$install_dir, $scripts_dir] :
+    ensure => directory,
   }
 
   if $manage_database_maintenance {

--- a/manifests/maintenance.pp
+++ b/manifests/maintenance.pp
@@ -3,7 +3,8 @@ class pe_databases::maintenance (
   Integer $maint_cron_weekday = 6,
   Integer $maint_cron_hour    = 1,
   Integer $maint_cron_minute  = 0,
-  String  $logging_directory  = '/var/log/puppetlabs/pe_databases_cron'
+  String  $logging_directory  = '/var/log/puppetlabs/pe_databases_cron',
+  String  $script_directory   = $pe_databases::scripts_dir,
 ){
 
   $ensure_cron = $disable_maintenace ? {
@@ -15,14 +16,54 @@ class pe_databases::maintenance (
     ensure => directory,
   }
 
+  $vacuum_script_path = "${script_directory}/vacuum_full_tables.sh"
+
+  file { $vacuum_script_path:
+    ensure => file,
+    source => 'puppet:///modules/pe_databases/vacuum_full_tables.sh',
+    owner  => 'pe-postgres',
+    group  => 'pe-postgres',
+    mode   => '744',
+  }
+
+  cron { 'VACUUM FULL facts tables' :
+    ensure   => $ensure_cron,
+    user     => 'root',
+    weekday => [2,6],
+    hour     => 4,
+    minute   => 30,
+    command  => "${vacuum_script_path} facts > ${logging_directory}/facts_output.log 2>| tee ${logging_directory}/facts_error.log",
+    require  => File[$logging_directory, $script_directory],
+  }
+
+  cron { 'VACUUM FULL catalogs tables' :
+    ensure   => $ensure_cron,
+    user     => 'root',
+    weekday  => [0,4],
+    hour     => 4,
+    minute   => 30,
+    command  => "${vacuum_script_path} catalogs > ${logging_directory}/catalogs_output.log 2>| tee ${logging_directory}/catalogs_error.log",
+    require  => File[$logging_directory, $script_directory],
+  }
+
+  cron { 'VACUUM FULL other tables' :
+    ensure   => $ensure_cron,
+    user     => 'root',
+    monthday => 20,
+    hour     => 5,
+    minute   => 30,
+    command  => "${vacuum_script_path} other > ${logging_directory}/other_output.log 2>| tee ${logging_directory}/other_error.log",
+    require  => File[$logging_directory, $script_directory],
+  }
+
+  #Remove old versions of maintenance cron jobs
   cron { 'Maintain PE databases' :
-    ensure  => $ensure_cron,
+    ensure  => absent,
     user    => 'root',
     weekday => $maint_cron_weekday,
     hour    => $maint_cron_hour,
     minute  => $maint_cron_minute,
     command => "su - pe-postgres -s /bin/bash -c '/opt/puppetlabs/server/bin/reindexdb --all; /opt/puppetlabs/server/bin/vacuumdb --analyze --verbose --all' > ${logging_directory}/output.log 2> ${logging_directory}/output_error.log",
-    require => File[$logging_directory],
+    require => File[$logging_directory, $script_directory],
   }
-
 }

--- a/manifests/maintenance.pp
+++ b/manifests/maintenance.pp
@@ -1,8 +1,8 @@
 class pe_databases::maintenance (
   Boolean $disable_maintenace = false,
-  Integer $maint_cron_weekday = 6,
-  Integer $maint_cron_hour    = 1,
-  Integer $maint_cron_minute  = 0,
+  Optional[Integer] $maint_cron_weekday = undef, #DEPRECATED
+  Optional[Integer] $maint_cron_hour    = undef, #DEPRECATED
+  Optional[Integer] $maint_cron_minute  = undef, #DEPRECATED
   String  $logging_directory  = '/var/log/puppetlabs/pe_databases_cron',
   String  $script_directory   = $pe_databases::scripts_dir,
 ){
@@ -65,5 +65,15 @@ class pe_databases::maintenance (
     minute  => $maint_cron_minute,
     command => "su - pe-postgres -s /bin/bash -c '/opt/puppetlabs/server/bin/reindexdb --all; /opt/puppetlabs/server/bin/vacuumdb --analyze --verbose --all' > ${logging_directory}/output.log 2> ${logging_directory}/output_error.log",
     require => File[$logging_directory, $script_directory],
+  }
+
+  if empty($maint_cron_weekday) == false {
+    warning('pe_databases::maintenance::maint_cron_weekday is deprecated and will be removed in a future release')
+  }
+  if empty($maint_cron_hour) == false {
+    warning('pe_databases::maintenance::maint_cron_hour is deprecated and will be removed in a future release')
+  }
+  if empty($maint_cron_minute) == false {
+    warning('pe_databases::maintenance::maint_cron_minute is deprecated and will be removed in a future release')
   }
 }

--- a/manifests/maintenance.pp
+++ b/manifests/maintenance.pp
@@ -32,7 +32,7 @@ class pe_databases::maintenance (
     weekday => [2,6],
     hour     => 4,
     minute   => 30,
-    command  => "${vacuum_script_path} facts > ${logging_directory}/facts_output.log 2>| tee ${logging_directory}/facts_error.log",
+    command  => "${vacuum_script_path} facts",
     require  => File[$logging_directory, $script_directory],
   }
 
@@ -42,7 +42,7 @@ class pe_databases::maintenance (
     weekday  => [0,4],
     hour     => 4,
     minute   => 30,
-    command  => "${vacuum_script_path} catalogs > ${logging_directory}/catalogs_output.log 2>| tee ${logging_directory}/catalogs_error.log",
+    command  => "${vacuum_script_path} catalogs",
     require  => File[$logging_directory, $script_directory],
   }
 
@@ -52,7 +52,7 @@ class pe_databases::maintenance (
     monthday => 20,
     hour     => 5,
     minute   => 30,
-    command  => "${vacuum_script_path} other > ${logging_directory}/other_output.log 2>| tee ${logging_directory}/other_error.log",
+    command  => "${vacuum_script_path} other",
     require  => File[$logging_directory, $script_directory],
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_databases",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "author": "npwalker",
   "summary": "A Puppet Module for Backing Up / Maintaining / Tuning Your Puppet Enterprise Databases",
   "license": "Apache-2.0",


### PR DESCRIPTION
We want to VACUUM FULL all the tables except reports and
resource events.  We do this across days and for some lesser used
tables we do this only once per month.