### PR TITLE
Add analyze when performing VACUUM FULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Z Release 0.12.1
+
+ - Add `--analyze` during VACUUM FULL commands run in maintenance [#13](https://github.com/npwalker/pe_databases/pull/13)
+
 ## Minor Release 0.12.0
 
  - Improve maintenance cron jobs [#12](https://github.com/npwalker/pe_databases/pull/12)

--- a/files/vacuum_full_tables.sh
+++ b/files/vacuum_full_tables.sh
@@ -30,6 +30,6 @@ SQL="SELECT t.relname::varchar AS table_name
 for TABLE in $(su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/bin/psql -d pe-puppetdb -c \"$SQL\" --tuples-only")
 do
   #echo $TABLE
-  su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/bin/vacuumdb -d pe-puppetdb -t $TABLE --full"
+  su - pe-postgres -s /bin/bash -c "/opt/puppetlabs/server/bin/vacuumdb -d pe-puppetdb -t $TABLE --full --analyze"
   sleep $SLEEP
 done

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_databases",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": "npwalker",
   "summary": "A Puppet Module for Backing Up / Maintaining / Tuning Your Puppet Enterprise Databases",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prior to this commit, we only did a VACUUM FULL.  However, this
already requires reading the whole table so it's advantageous to
also analyze the table at the same time.  Otherwise autovacuum
will come around and analyze the table later when it could have
already been complted during the VACUUM FULL.

After this commit, we add --analyze to vacuumdb.