### PR TITLE
Add autovacuum settings for certnames and catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Minor Release 0.13.0
+
+ - Manage certnames and catalogs tables autovacuum_vacuum_scale_factor [#14](https://github.com/npwalker/pe_databases/pull/14)
+ - Change way we cast strings to appease puppet lint
+
 ## Z Release 0.12.1
 
  - Add `--analyze` during VACUUM FULL commands run in maintenance [#13](https://github.com/npwalker/pe_databases/pull/13)

--- a/manifests/postgresql_settings.pp
+++ b/manifests/postgresql_settings.pp
@@ -56,43 +56,43 @@ class pe_databases::postgresql_settings (
   }
 
   postgresql_conf { 'autovacuum_vacuum_scale_factor' :
-    value => "${autovacuum_vacuum_scale_factor}",
+    value => sprintf('%#.2f', $autovacuum_vacuum_scale_factor),
   }
 
   postgresql_conf { 'autovacuum_analyze_scale_factor' :
-    value => "${autovacuum_analyze_scale_factor}",
+    value => sprintf('%#.2f', $autovacuum_analyze_scale_factor),
   }
 
   postgresql_conf { 'autovacuum_max_workers' :
-    value => "${autovacuum_max_workers}",
+    value => String($autovacuum_max_workers),
   }
 
   postgresql_conf { 'autovacuum_work_mem' :
-    value => "${autovacuum_work_mem}",
+    value => String($autovacuum_work_mem),
   }
 
   postgresql_conf { 'log_autovacuum_min_duration' :
-    value => "${log_autovacuum_min_duration}",
+    value => String($log_autovacuum_min_duration),
   }
 
   postgresql_conf { 'log_temp_files' :
-    value => "${log_temp_files}",
+    value => String($log_temp_files),
   }
 
   postgresql_conf { 'maintenance_work_mem' :
-    value => "${maintenance_work_mem}",
+    value => String($maintenance_work_mem),
   }
 
   postgresql_conf { 'work_mem' :
-    value => "${work_mem}",
+    value => String($work_mem),
   }
 
   postgresql_conf { 'max_connections' :
-    value => "${max_connections}",
+    value => String($max_connections),
   }
 
   postgresql_conf { 'checkpoint_completion_target' :
-    value => "${checkpoint_completion_target}",
+    value => sprintf('%#.2f', $checkpoint_completion_target),
   }
 
   $checkpoint_segments_ensure = $psql_version ? {
@@ -102,7 +102,7 @@ class pe_databases::postgresql_settings (
 
   postgresql_conf { 'checkpoint_segments' :
     ensure => $checkpoint_segments_ensure,
-    value  => "${checkpoint_segments}",
+    value  => String($checkpoint_segments),
   }
 
   if !empty($arbitrary_postgresql_conf_settings) {

--- a/manifests/postgresql_settings.pp
+++ b/manifests/postgresql_settings.pp
@@ -113,31 +113,10 @@ class pe_databases::postgresql_settings (
     }
   }
 
-  if ( ( versioncmp('2017.2.0', $facts['pe_server_version']) > 0 or
-         versioncmp('2017.3.0', $facts['pe_server_version']) <= 0 )
-       and $manage_fact_values_autovacuum_cost_delay ) {
-    pe_databases::set_puppetdb_table_autovacuum_cost_delay_zero { 'fact_values' : }
-  }
-
-  if !empty($factsets_autovacuum_vacuum_scale_factor) {
-    pe_databases::set_table_attribute { "Set autovacuum_vacuum_scale_factor=${factsets_autovacuum_vacuum_scale_factor} for factsets" :
-      db                    => 'pe-puppetdb',
-      table_name            => 'factsets',
-      table_attribute       => 'autovacuum_vacuum_scale_factor',
-      table_attribute_value => "${factsets_autovacuum_vacuum_scale_factor}",
-    }
-  }
-
-  if !empty($reports_autovacuum_vacuum_scale_factor) {
-    pe_databases::set_table_attribute { "Set autovacuum_vacuum_scale_factor=${reports_autovacuum_vacuum_scale_factor} for reports" :
-      db                    => 'pe-puppetdb',
-      table_name            => 'reports',
-      table_attribute       => 'autovacuum_vacuum_scale_factor',
-      table_attribute_value => "${reports_autovacuum_vacuum_scale_factor}",
-    }
-  }
-
-  if $manage_reports_autovacuum_cost_delay {
-    pe_databases::set_puppetdb_table_autovacuum_cost_delay_zero { 'reports' : }
+  class { 'pe_databases::postgresql_settings::table_settings' :
+    manage_fact_values_autovacuum_cost_delay => $manage_fact_values_autovacuum_cost_delay,
+    manage_reports_autovacuum_cost_delay     => $manage_reports_autovacuum_cost_delay,
+    factsets_autovacuum_vacuum_scale_factor  => $factsets_autovacuum_vacuum_scale_factor,
+    reports_autovacuum_vacuum_scale_factor   => $reports_autovacuum_vacuum_scale_factor,
   }
 }

--- a/manifests/postgresql_settings/table_settings.pp
+++ b/manifests/postgresql_settings/table_settings.pp
@@ -1,0 +1,55 @@
+class pe_databases::postgresql_settings::table_settings (
+  Boolean    $manage_fact_values_autovacuum_cost_delay = $pe_databases::postgresql_settings::manage_fact_values_autovacuum_cost_delay,
+  Boolean    $manage_reports_autovacuum_cost_delay     = $pe_databases::postgresql_settings::manage_reports_autovacuum_cost_delay,
+  Optional[Float[0,1]] $factsets_autovacuum_vacuum_scale_factor = $pe_databases::postgresql_settings::factsets_autovacuum_vacuum_scale_factor,
+  Optional[Float[0,1]] $reports_autovacuum_vacuum_scale_factor  = $pe_databases::postgresql_settings::reports_autovacuum_vacuum_scale_factor,
+  Optional[Float[0,1]] $catalogs_autovacuum_vacuum_scale_factor = 0.75,
+  Optional[Float[0,1]] $certnames_autovacuum_vacuum_scale_factor = 0.75,
+) {
+
+  if ( ( versioncmp('2017.2.0', $facts['pe_server_version']) > 0 or
+         versioncmp('2017.3.0', $facts['pe_server_version']) <= 0 )
+       and $manage_fact_values_autovacuum_cost_delay ) {
+    pe_databases::set_puppetdb_table_autovacuum_cost_delay_zero { 'fact_values' : }
+  }
+
+  if !empty($factsets_autovacuum_vacuum_scale_factor) {
+    pe_databases::set_table_attribute { "Set autovacuum_vacuum_scale_factor=${factsets_autovacuum_vacuum_scale_factor} for factsets" :
+      db                    => 'pe-puppetdb',
+      table_name            => 'factsets',
+      table_attribute       => 'autovacuum_vacuum_scale_factor',
+      table_attribute_value => "${factsets_autovacuum_vacuum_scale_factor}",
+    }
+  }
+
+  if !empty($reports_autovacuum_vacuum_scale_factor) {
+    pe_databases::set_table_attribute { "Set autovacuum_vacuum_scale_factor=${reports_autovacuum_vacuum_scale_factor} for reports" :
+      db                    => 'pe-puppetdb',
+      table_name            => 'reports',
+      table_attribute       => 'autovacuum_vacuum_scale_factor',
+      table_attribute_value => "${reports_autovacuum_vacuum_scale_factor}",
+    }
+  }
+
+  if !empty($catalogs_autovacuum_vacuum_scale_factor) {
+    pe_databases::set_table_attribute { "Set autovacuum_vacuum_scale_factor=${catalogs_autovacuum_vacuum_scale_factor} for catalogs" :
+      db                    => 'pe-puppetdb',
+      table_name            => 'catalogs',
+      table_attribute       => 'autovacuum_vacuum_scale_factor',
+      table_attribute_value => "${catalogs_autovacuum_vacuum_scale_factor}",
+    }
+  }
+
+  if !empty($certnames_autovacuum_vacuum_scale_factor) {
+    pe_databases::set_table_attribute { "Set autovacuum_vacuum_scale_factor=${certnames_autovacuum_vacuum_scale_factor} for certnames" :
+      db                    => 'pe-puppetdb',
+      table_name            => 'certnames',
+      table_attribute       => 'autovacuum_vacuum_scale_factor',
+      table_attribute_value => "${certnames_autovacuum_vacuum_scale_factor}",
+    }
+  }
+
+  if $manage_reports_autovacuum_cost_delay {
+    pe_databases::set_puppetdb_table_autovacuum_cost_delay_zero { 'reports' : }
+  }
+}

--- a/manifests/postgresql_settings/table_settings.pp
+++ b/manifests/postgresql_settings/table_settings.pp
@@ -18,7 +18,7 @@ class pe_databases::postgresql_settings::table_settings (
       db                    => 'pe-puppetdb',
       table_name            => 'factsets',
       table_attribute       => 'autovacuum_vacuum_scale_factor',
-      table_attribute_value => "${factsets_autovacuum_vacuum_scale_factor}",
+      table_attribute_value => sprintf('%#.2f', $factsets_autovacuum_vacuum_scale_factor),
     }
   }
 
@@ -27,7 +27,7 @@ class pe_databases::postgresql_settings::table_settings (
       db                    => 'pe-puppetdb',
       table_name            => 'reports',
       table_attribute       => 'autovacuum_vacuum_scale_factor',
-      table_attribute_value => "${reports_autovacuum_vacuum_scale_factor}",
+      table_attribute_value => sprintf('%#.2f', $reports_autovacuum_vacuum_scale_factor),
     }
   }
 
@@ -36,7 +36,7 @@ class pe_databases::postgresql_settings::table_settings (
       db                    => 'pe-puppetdb',
       table_name            => 'catalogs',
       table_attribute       => 'autovacuum_vacuum_scale_factor',
-      table_attribute_value => "${catalogs_autovacuum_vacuum_scale_factor}",
+      table_attribute_value => sprintf('%#.2f', $catalogs_autovacuum_vacuum_scale_factor),
     }
   }
 
@@ -45,7 +45,7 @@ class pe_databases::postgresql_settings::table_settings (
       db                    => 'pe-puppetdb',
       table_name            => 'certnames',
       table_attribute       => 'autovacuum_vacuum_scale_factor',
-      table_attribute_value => "${certnames_autovacuum_vacuum_scale_factor}",
+      table_attribute_value => sprintf('%#.2f', $certnames_autovacuum_vacuum_scale_factor),
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker/pe_databases",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "author": "npwalker",
   "summary": "A Puppet Module for Backing Up / Maintaining / Tuning Your Puppet Enterprise Databases",
   "license": "Apache-2.0",


### PR DESCRIPTION
Break out table settings into its own class to avoid parameter
overload on the postgresql_settings class.