### PR TITLE
Set permissions on /opt/puppetlabs/pe_databases and /opt/puppetlabs/pe_databases/scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.git/
 .*.sw[op]
 .metadata
 .yardoc

--- a/.pdkignore
+++ b/.pdkignore
@@ -1,3 +1,4 @@
+.git/
 .*.sw[op]
 .metadata
 .yardoc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,6 +71,7 @@ RSpec/MessageSpies:
 Style/Documentation:
   Exclude:
   - lib/puppet/parser/functions/**/*
+  - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
 Style/CollectionMethods:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Z Release 0.14.1
+
+ - Set permissions on pe_databases directories [#18](https://github.com/npwalker/pe_databases/pull/18)
+ - Log pe-classifier truncation to log files instead of STDOUT [#18](https://github.com/npwalker/pe_databases/pull/18)
+
 ## Minor Release 0.14.0
 
 - Make compatible with PE 2018.1 [#17](https://github.com/npwalker/pe_databases/pull/17)

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-blacksmith", '~> 3.4',                   require: false, platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,74 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
+require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
+
+def changelog_user
+  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
+  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator user:#{returnVal}"
+  returnVal
+end
+
+def changelog_project
+  returnVal = nil || JSON.load(File.read('metadata.json'))['name']
+  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator project:#{returnVal}"
+  returnVal
+end
+
+def changelog_future_release
+  returnVal = JSON.load(File.read('metadata.json'))['version']
+  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
+  puts "GitHubChangelogGenerator future_release:#{returnVal}"
+  returnVal
+end
 
 PuppetLint.configuration.send('disable_relative')
 PuppetLint.configuration.send('disable_2sp_soft_tabs')
 PuppetLint.configuration.send('disable_arrow_alignment')
+
+if Bundler.rubygems.find_name('github_changelog_generator').any?
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if ENV['CHANGELOG_GITHUB_TOKEN'].nil?
+    config.user = "#{changelog_user}"
+    config.project = "#{changelog_project}"
+    config.future_release = "#{changelog_future_release}"
+    config.exclude_labels = ['maintenance']
+    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
+    config.add_pr_wo_labels = true
+    config.issues = false
+    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.configure_sections = {
+      "Changed" => {
+        "prefix" => "### Changed",
+        "labels" => ["backwards-incompatible"],
+      },
+      "Added" => {
+        "prefix" => "### Added",
+        "labels" => ["feature", "enhancement"],
+      },
+      "Fixed" => {
+        "prefix" => "### Fixed",
+        "labels" => ["bugfix"],
+      },
+    }
+  end
+else
+  desc 'Generate a Changelog from GitHub'
+  task :changelog do
+    raise <<EOM
+The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+Please manually add it to your .sync.yml for now, and run `pdk update`:
+---
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'github_changelog_generator'
+        git: 'https://github.com/skywinder/github-changelog-generator'
+        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+EOM
+  end
+end
 

--- a/files/puppet_enterprise_database_backup.sh
+++ b/files/puppet_enterprise_database_backup.sh
@@ -42,9 +42,9 @@ for db in $DATABASES; do
 
   if [ ${db} == "pe-classifier" ]; then
     #Save space before backing up by clearing unused node_check_ins table
-    /opt/puppetlabs/server/bin/psql -d pe-classifier -c 'TRUNCATE TABLE node_check_ins'
+    /opt/puppetlabs/server/bin/psql -d pe-classifier -c 'TRUNCATE TABLE node_check_ins' >> ${LOGDIR}/${db}.log 2>&1
     if [ $? != 0 ]; then
-      echo "Failed to truncate node_check_ins table."
+      echo "Failed to truncate node_check_ins table." >> ${LOGDIR}/${db}.log 2>&1
     fi
   fi
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class pe_databases (
 
   file { [$install_dir, $scripts_dir] :
     ensure => directory,
+    mode   => '0755',
   }
 
   if $manage_database_maintenance {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "npwalker-pe_databases",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": "npwalker",
   "summary": "A Puppet Module for Backing Up / Maintaining / Tuning Your Puppet Enterprise Databases",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -72,7 +72,7 @@
       "version_requirement": ">= 4.0"
     }
   ],
-  "pdk-version": "1.6.0.pre (heads/master-0-g1c719d9)",
+  "pdk-version": "1.7.0.pre (heads/master-0-ga78db1e)",
   "template-url": "https://github.com/puppetlabs/pdk-templates",
-  "template-ref": "heads/master-0-g7b5f6d2"
+  "template-ref": "heads/master-0-g473cd94"
 }


### PR DESCRIPTION
When umask is restrictive (eg: 0077), the pe-postgres user cannot access /opt/puppetlabs/pe_databases/scripts because the mode becomes 0700 and is owned by root. This sets the mode to 0755 which allows pe-postgres to access the scripts.

I also fixed a minor logging issue in the backup script. It was putting the truncate command output to stdout instead of into the log.

This fixes https://github.com/npwalker/pe_databases/issues/19