### PR TITLE
 PE Database is a reserved node group name in 2019.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ By default you get the following:
 
 In order to use this module, you will classify the node running pe-postgresql with the `pe_databases` class.  This is the MoM in a monolithic installation or the PuppetDB node in a Split/LEI install.  
 
-To classify via the PE console, you will create a new node group called 'PE Database' and pin the node running pe-postgresql to the group.  It is not recommended to classify using a pre-existing node group in the PE console.
+To classify via the PE console, you will create a new node group with a name meaningful for this task. Then pin the node running pe-postgresql to this group.  It is not recommended to classify using a pre-existing node group in the PE console.
 
 ## Items you may want to configure
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ By default you get the following:
 
 In order to use this module, you will classify the node running pe-postgresql with the `pe_databases` class.  This is the MoM in a monolithic installation or the PuppetDB node in a Split/LEI install.  
 
-To classify via the PE console, you will create a new node group with a name meaningful for this task. Then pin the node running pe-postgresql to this group.  It is not recommended to classify using a pre-existing node group in the PE console.
+To classify via the PE console, you will create a new node group called "PE Database Maintenance". Then pin the node running pe-postgresql to this group.  It is not recommended to classify using a pre-existing node group in the PE console.
 
 ## Items you may want to configure
 


### PR DESCRIPTION
Removed reference to  creating a group with name "PE Database" since this is one of the core groups now, it could be confusing to the user.

